### PR TITLE
Fix NullPointerException in IgnitePostgresDbMetricsExporter at shutdowm

### DIFF
--- a/src/main/java/org/eclipse/ecsp/sql/postgress/metrics/IgnitePostgresDbMetricsExporter.java
+++ b/src/main/java/org/eclipse/ecsp/sql/postgress/metrics/IgnitePostgresDbMetricsExporter.java
@@ -226,6 +226,8 @@ public class IgnitePostgresDbMetricsExporter {
             LOGGER.info("Shutting down the PostgresDB metrics executor...");
             ThreadUtils.shutdownExecutor(postgresDbMetricsExecutor, shutdownBuffer, false);
         }
-        prometheusExportServer.stop();
+        if (prometheusExportServer != null) {
+            prometheusExportServer.stop();
+        }
     }
 }


### PR DESCRIPTION
Resolves #ISSUE_NUMBER 
[<!-- Link to related issue(s) -->](https://github.com/eclipse-ecsp/sql-dao/issues/14)

----
### Describe behaviour before the change
* NullPointerException  was occurring during shutdown since prometheusExportServer is initialized based on a configuration, can can be a case where it is not being used.

### Describe behaviour after the change
* Added a null check on prometheusExportServer  before closing it.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----

