### PR TITLE
Issue #1052 SQL DAO Connection Leak bug fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.ecsp</groupId>
 	<artifactId>sql-dao</artifactId>
-	<version>1.3-SNAPSHOT</version>
+	<version>1.3-health-check-bug-SNAPSHOT</version>
 	
 	<name>SQL DAO Library</name>
 	<description>DAO framework for SQL databases</description>

--- a/src/main/java/org/eclipse/ecsp/sql/dao/constants/PostgresDbConstants.java
+++ b/src/main/java/org/eclipse/ecsp/sql/dao/constants/PostgresDbConstants.java
@@ -130,8 +130,11 @@ public class PostgresDbConstants {
     /** Default maximum pool size. */
     public static final int DEFAULT_MAX_POOL_SIZE = 10;
     
-    /** Default maximum idle time in seconds. */
-    public static final int DEFAULT_MAX_IDLE_TIME = 600;
+    /** Default maximum idle time in milliseconds (10 minutes). */
+    public static final int DEFAULT_MAX_IDLE_TIME = 600000;
+
+    /** Default keep alive time in milliseconds (1 minute - must be shorter than network idle timeout). */
+    public static final int DEFAULT_KEEP_ALIVE_TIME = 60000;
     
     /** Default cache prepared statements value. */
     public static final String DEFAULT_CACHE_PREP_STMTS = "true";

--- a/src/main/java/org/eclipse/ecsp/sql/multitenancy/DatabaseProperties.java
+++ b/src/main/java/org/eclipse/ecsp/sql/multitenancy/DatabaseProperties.java
@@ -327,4 +327,18 @@ public interface DatabaseProperties {
      * @param rootCrtPath the root certificate path to set
      */
     void setRootCrtPath(String rootCrtPath);
+
+    /**
+     * Gets the keep alive time in milliseconds.
+     * HikariCP periodically pings idle connections at this interval to prevent
+     * them from being silently dropped by network infrastructure.
+     * @return the keep alive time
+     */
+    int getKeepAliveTime();
+
+    /**
+     * Sets the keep alive time in milliseconds.
+     * @param keepAliveTime the keep alive time to set
+     */
+    void setKeepAliveTime(int keepAliveTime);
 }

--- a/src/main/java/org/eclipse/ecsp/sql/multitenancy/TenantDatabaseProperties.java
+++ b/src/main/java/org/eclipse/ecsp/sql/multitenancy/TenantDatabaseProperties.java
@@ -128,4 +128,7 @@ public class TenantDatabaseProperties implements DatabaseProperties {
 
 	// Root certificate path
 	private String rootCrtPath = "";
+
+	// Keep alive time in milliseconds
+	private int keepAliveTime = PostgresDbConstants.DEFAULT_KEEP_ALIVE_TIME;
 }

--- a/src/main/java/org/eclipse/ecsp/sql/postgress/config/PostgresDbConfig.java
+++ b/src/main/java/org/eclipse/ecsp/sql/postgress/config/PostgresDbConfig.java
@@ -285,10 +285,12 @@ public class PostgresDbConfig {
         LOGGER.debug("Cleaning up existing connections for tenant ID: {}.", tenantId);
         cleanupConnections(targetDataSources.get(tenantId));
         LOGGER.info("Creating connection with refreshed credentials...");
-        try {
-            Connection connection = createConnections(tenantId, props);
+        try (Connection connection = createConnections(tenantId, props)) {
+            if (!connection.isValid(1)) {
+                throw new SqlDaoException("Connection validation failed after credentials refresh for tenant: " + tenantId);
+            }
             LOGGER.info(
-                    "Connection created successfully with refreshed credentials for tenant ID: {}.",
+                    "Connection verified with refreshed credentials for tenant ID: {}.",
                     tenantId);
         } catch (Exception exception) {
             try {
@@ -312,7 +314,6 @@ public class PostgresDbConfig {
             throws InterruptedException, SQLException {
         int connectionRetryCount = dbProperties.getConnectionRetryCount();
         int connectionRetryDelay = dbProperties.getConnectionRetryDelay();
-        Connection connection;
         do {
             try {
                 Thread.sleep(connectionRetryDelay);
@@ -320,9 +321,12 @@ public class PostgresDbConfig {
                         tenantId, connectionRetryCount);
                 connectionRetryCount--;
                 dbProperties.setConnectionRetryCount(connectionRetryCount);
-                connection = createConnections(tenantId, dbProperties);
-                if (connection != null && !connection.isValid(1)) {
-                    continue;
+                try (Connection connection = createConnections(tenantId, dbProperties)) {
+                    if (connection.isValid(1)) {
+                        LOGGER.info("Connection validated successfully for tenant ID: {}. Retry successful.", tenantId);
+                        return;
+                    }
+                    LOGGER.warn("Connection validation failed for tenant ID: {}. Retrying...", tenantId);
                 }
             } catch (Exception e) {
                 if (connectionRetryCount == 0) {
@@ -409,8 +413,7 @@ public class PostgresDbConfig {
                 }
             }
         }
-        try {
-            Connection connection = targetDataSources.get(tenantId).getConnection();
+        try (Connection connection = targetDataSources.get(tenantId).getConnection()) {
             LOGGER.info("Datasource and connection created successfully for tenantId: {}", tenantId);
         } catch (Exception exception) {
             LOGGER.error( "Exception occurred while creating connection for tenantId: {}, exception is: {}",
@@ -479,6 +482,7 @@ public class PostgresDbConfig {
         config.setIdleTimeout(dbProperties.getMaxIdleTime());
         config.setPoolName(dbProperties.getPoolName());
         config.setConnectionTimeout(dbProperties.getConnectionTimeoutMs());
+        config.setKeepaliveTime(dbProperties.getKeepAliveTime());
         config.addHealthCheckProperty(HealthConstants.POSTGRES_EXPECTED_99_PI_MS,
                 dbProperties.getExpected99thPercentileMsValue());
         config.addDataSourceProperty(PostgresDbConstants.POSTGRES_DS_CACHE_PREPARED_STATEMENTS,


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves https://github.com/HARMAN-Auto/sp-platform-e2e-productenablers/issues/1052

----
### Describe behaviour before the change
After ~15 minutes of uptime, the PostgreSQL health check starts throwing SQLTransientConnectionException: Connection is not available, request timed out after 60001ms and never recovers without a restart.

* Bug 1: HikariCP Connection Pool Exhaustion (Connection Leak)

- createConnection() in PostgresDbConfig acquires a connection from the HikariCP pool and returns it to the caller. Neither caller ever closed the returned connection.
- When postgresCredRefreshEnabled=true and the postgresCredsRefreshJob fires, each execution permanently consumed one slot from the pool. With maximumPoolSize=10, the pool was fully exhausted after 9 refresh cycles. After that, every call to getConnection() — including the health check — waited the full connectionTimeout (60 seconds) before throwing the exception.

* Bug 2: Stale Connections Due to Missing Keep-Alive

- createAndGetDataSource() method never configured keepaliveTime on the HikariCP pool. Network infrastructure (AWS NAT Gateway, firewalls, load balancers) silently drops TCP connections that are idle for ~10–15 minutes. HikariCP had no mechanism to detect or prevent this — idle connections in the pool would become "half-open" dead sockets without HikariCP's knowledge.

When the health check's ConnectivityHealthCheck tried to use one of these stale connections, the socket appeared open at the OS level but the database had already closed its end. The JDBC driver's isValid() method call hung waiting for a response that never came, eventually exhausting the 60-second connectionTimeout.


### Describe behaviour after the change
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Fixed the leak sites
* Added keepAliveTime to HikarCP configuration.

### Pull request checklist
- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All new and existing tests passed.
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [ ] No

----

